### PR TITLE
Update pluggable_rule_engine.md

### DIFF
--- a/docs/plugins/pluggable_rule_engine.md
+++ b/docs/plugins/pluggable_rule_engine.md
@@ -157,6 +157,9 @@ Monitoring the delayed queue is important once your workflows and maintenance sc
 2. iqmod    - modify certain values in existing delayed rules (owned by you).
 3. iqdel    - remove a delayed rule (owned by you) from the queue.
 
+!!! Note
+    Actions that are being executed by a delay are bound to a maximum size. A rule that is over 2700 characters long cannot be executed by a delay or remote command.  This is fixed by using policy functions and loading the functions as a .re file.
+
 ### Syntax
 
 The `delay` microservice is invoked with the following syntax:


### PR DESCRIPTION
We ran in trouble with using delayed rules larger than 2700 characters. 
I found the solution in a slide made by Jason Coposky (http://slides.com/irods/debugging-rules-and-microservices-17#/4).

Since this was nowhere to be found in the iRODS documentation, I propose this addition.