### PR TITLE
Fix irodsctl location in auth documentation

### DIFF
--- a/docs/plugins/pluggable_authentication.md
+++ b/docs/plugins/pluggable_authentication.md
@@ -304,7 +304,7 @@ The server expects to have the following irods service account's `irods_environm
 Restart the server:
 
 ~~~
-irods@hostname:~/ $ ./iRODS/irodsctl restart
+irods@hostname:~/ $ ./irodsctl restart
 ~~~
 
 ### Client SSL Setup


### PR DESCRIPTION
The iRODS directory no longer exists in /var/lib/irods as of 4.2+ so the location of irodsctl needs to be updated.