### PR TITLE
correct names of api PEPS for put,get,copy

### DIFF
--- a/dynamic_peps.json
+++ b/dynamic_peps.json
@@ -1768,7 +1768,7 @@
 				"paramName": "collOprStat"
 			}]
 		}, {
-			"funcName": "api_data_copy",
+			"funcName": "api_data_obj_copy",
 			"paramList": [{
 				"paramType": "rsComm_t *",
 				"paramName": "rsComm"
@@ -1777,7 +1777,7 @@
 				"paramName": "dataCopyInp"
 			}]
 		}, {
-			"funcName": "api_data_get",
+			"funcName": "api_data_obj_get",
 			"paramList": [{
 				"paramType": "rsComm_t *",
 				"paramName": "rsComm"
@@ -2011,7 +2011,7 @@
 				"paramName": "dataObjWriteInpBBuf"
 			}]
 		}, {
-			"funcName": "api_data_put",
+			"funcName": "api_data_obj_put",
 			"paramList": [{
 				"paramType": "rsComm_t *",
 				"paramName": "rsComm"


### PR DESCRIPTION
As recently as 4.2.5 (https://docs.irods.org/4.2.5/plugins/dynamic_policy_enforcement_points/#available-dynamic-peps) irods documentation online has misspelled the pre- and post-PEPs for data_obj GET, PUT and COPY operations. This is a fix for that document.