### PR TITLE
[irods/irods#6465] add INST_NAME to change remote call documentation

### DIFF
--- a/docs/plugins/pluggable_rule_engine.md
+++ b/docs/plugins/pluggable_rule_engine.md
@@ -243,6 +243,7 @@ remote("host","hints") {
 "hints" (required) are of the form:
 
   - `ZONE` - Remote Zone - The name of the Zone in which the "host" is located.
+  - `INST_NAME` - Instance Name - The name of the Rule Engine Plugin instance to target on the remote host.
 
 ### Examples
 


### PR DESCRIPTION
This small change documents a new feature in iRODS server whereby INST_NAME can be used alongside other hints in the 2nd parameter of the irods rule language's remote( ) execution call.

A corresponding feature is being added to the the Python RE plugin's py_remote( ) microservice and  will be separately documented in that repo's front page README.