### PR TITLE
[#216] Update builder image

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -2,7 +2,7 @@ name: build-docs
 on: [push, pull_request]
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -13,12 +13,10 @@ jobs:
       - name: Install Dependencies
         run:  |
               sudo apt-get update -qq
-              sudo apt-get install -qq python-virtualenv g++
+              sudo apt-get install -qq python3-virtualenv g++
       - name: Install iRODS Repository
         run:  |
-              curl https://packages.irods.org/irods-signing-key.asc -o key.asc
-              cat key.asc
-              sudo apt-key add key.asc
+              wget -qO- https://packages.irods.org/irods-signing-key.asc | sudo tee /etc/apt/trusted.gpg.d/irods-signing-key.asc
               echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/renci-irods.list
               sudo apt-get update
               sudo apt-get install irods-icommands cmake cmake-data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,45 +1,42 @@
-#
-# iRODS Build Documentation
-#
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN \
-  apt-get update && \
-  apt-get install -y \
-    python3 \
-    lsb-release \
-    git \
-    tig \
-    nano \
-    python3-venv \
-    make \
-    cmake \
-    g++ \
-    flex \
-    bison \
-    wget \
-    gnupg \
-    rsync \
-  && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists/* /tmp/*
+RUN apt-get update && \
+    apt-get install -y \
+        bison \
+        cmake \
+        flex \
+        g++ \
+        git \
+        gnupg \
+        lsb-release \
+        make \
+        nano \
+        python3 \
+        python3-pip \
+        python3-venv \
+        rsync \
+        tig \
+        wget \
+    && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/*
 
-RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add - && \
+RUN wget -qO- https://packages.irods.org/irods-signing-key.asc | tee /etc/apt/trusted.gpg.d/renci-irods-signing-key.asc && \
     echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods.list && \
-    wget -qO - https://core-dev.irods.org/irods-core-dev-signing-key.asc | apt-key add - && \
+    wget -qO- https://core-dev.irods.org/irods-core-dev-signing-key.asc | tee /etc/apt/trusted.gpg.d/renci-irods-core-dev-signing-key.asc && \
     echo "deb [arch=amd64] https://core-dev.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods-core-dev.list
 
-RUN \
-  apt-get update && \
-  apt-get install -y irods-icommands && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists/* /tmp/*
+RUN apt-get update && \
+    apt-get install -y \
+        irods-icommands \
+    && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/*
 
-RUN \
-  mkdir -p /root/.irods && \
-  echo "{}" | tee /root/.irods/irods_environment.json
+RUN mkdir -p /root/.irods && \
+    echo "{}" | tee /root/.irods/irods_environment.json
 
 COPY run_make.sh /run_make.sh
 ENTRYPOINT ["bash", "/run_make.sh"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ MarkupSafe==2.0.1
 mergedeep==1.3.4
 mkdocs==1.2.3
 packaging==21.3
-pkg-resources==0.0.0
 pyparsing==3.0.7
 python-dateutil==2.8.2
 PyYAML==6.0


### PR DESCRIPTION
Addresses #216 

We can't update to Ubuntu 22.04 until 4.3.1 is released. In the meantime, this seems to work both in GitHub Actions and on my local machine (docker version 24.0.6).