### PR TITLE
Add EOL policy to downloads page (main)

### DIFF
--- a/docs/getting_started/download.md
+++ b/docs/getting_started/download.md
@@ -10,6 +10,10 @@ More combinations will be made available as our testing matrix continues to matu
 
 The latest packages can be downloaded from our APT and YUM repositories hosted at [https://packages.irods.org](https://packages.irods.org).
 
+### Packages and Platform End-of-Life (EOL) Policy
+
+The iRODS Consortium will publish packages for the lifetime of a supported platform. Once a platform reaches EOL, the iRODS Consortium will make a reasonable effort to provide one additional set of packages to aid administrators in gracefully moving to a new platform.
+
 ## Open Source
 
 Code repositories, issue trackers, and milestones are available on GitHub.


### PR DESCRIPTION
There are two commits, each mostly presenting the same information, just in different ways.

Let me know which one seems better.