### PR TITLE
[#230,#231] Fix broken links

### DIFF
--- a/docs/administrators/policy_cookbook.md
+++ b/docs/administrators/policy_cookbook.md
@@ -398,13 +398,13 @@ And inspect the log file at `/var/log/irods/irods.log`, you'd see a log message 
 
 The prototype implementation of the Logical Quotas Rule Engine Plugin used this technique. You can find the implementation at [https://github.com/irods/irods_policy_examples/blob/main/irods_policy_logical_quotas.re](https://github.com/irods/irods_policy_examples/blob/main/irods_policy_logical_quotas.re)
 
-Additional documentation can be found at [Using temporaryStorage in the iRODS Rule Language](/system_overview/tips_and_tricks/#using-temporarystorage-in-the-irods-rule-language).
+Additional documentation can be found at [Using temporaryStorage in the iRODS Rule Language](../system_overview/tips_and_tricks/#using-temporarystorage-in-the-irods-rule-language).
 
 ## Simulating User Quotas
 
 This example demonstrates how to simulate user quotas using group quotas.
 
-As of iRODS 4.3.0, support for user quotas has been partially disabled. Please consult [iadmin suq](/icommands/administrator/#suq) and the [release notes](/release_notes) for more information.
+As of iRODS 4.3.0, support for user quotas has been partially disabled. Please consult [iadmin suq](../../icommands/administrator/#suq) and the [release notes](../../release_notes) for more information.
 
 ### How to do it ...
 
@@ -419,7 +419,7 @@ acRescQuotaPolicy { msiSetRescQuotaPolicy("on"); }
 
 When implementing this policy, we recommend applying this change to all servers in the local zone. That guarantees that all servers enforce the quotas. Keep in mind that this is only a recommendation. You should use a testing environment to verify behavior if you decide not to follow this recommendation.
 
-iRODS does not update the quota information following user interaction. To do that, you're going to need to periodically tell iRODS to update the quota information. One way to do that is by running [iadmin cu](/icommands/administrator/#cu) periodically. How you do that is up to you. You can use **cron** or any other tool you find convenient to use. The important thing is that the command runs.
+iRODS does not update the quota information following user interaction. To do that, you're going to need to periodically tell iRODS to update the quota information. One way to do that is by running [iadmin cu](../../icommands/administrator/#cu) periodically. How you do that is up to you. You can use **cron** or any other tool you find convenient to use. The important thing is that the command runs.
 
 #### Step 2: Setup the user quota
 

--- a/docs/developers/library_examples.md
+++ b/docs/developers/library_examples.md
@@ -2,7 +2,7 @@
 
 This section provides examples demonstrating how to use various C/C++ libraries provided by iRODS.
 
-You can find more information about the libraries presented by visiting the [Doxygen documentation](/doxygen/index.html).
+You can find more information about the libraries presented by visiting the [Doxygen documentation](../../doxygen/index.html).
 
 If you'd like to request examples of other libraries and APIs, please create an issue at [https://github.com/irods/irods_docs](https://github.com/irods/irods_docs).
 


### PR DESCRIPTION
Addresses #230 
Addresses #231

I did not transfer these issues to the 4.3.2 milestone in case we wanted to fix this in 4.3.1 documentation as well. Even if we don't, I wouldn't consider this a blocker for 4.3.2, so that is why I left them. Please let me know if we'd rather these issues be in the 4.3.2 milestone and I will transfer them and update the issue numbers appropriately.

Verified locally, but the problem does not manifest on locally running irods_docs sites, so it's hard to tell. I just copied how other places linked to these same pages in other places since those links work.