### PR TITLE
[irods/irods#7392] Fix: Remove '(optional)' from required option (main)

### DIFF
--- a/docs/system_overview/configuration.md
+++ b/docs/system_overview/configuration.md
@@ -520,7 +520,6 @@ This is the main iRODS configuration file defining the iRODS environment. Any ch
     // - CS_NEG_DONT_CARE: Let the server decide if SSL should be used
     "irods_client_server_policy": "CS_NEG_REFUSE",
 
-    // (Optional)
     // Number of seconds after which an existing connection in a connection pool is refreshed.
     "irods_connection_pool_refresh_time_in_seconds": 300,
 


### PR DESCRIPTION
Issue quick link: irods/irods#7392.

`irods_connection_pool_refresh_time_in_seconds` is not optional since 4.3.1, so this change removes the `(Optional)` annotation from the documentation.