### PR TITLE
[irods/irods#7949] Add note about deprecating parallel transfer over the high ports (main)

### DIFF
--- a/docs/system_overview/configuration.md
+++ b/docs/system_overview/configuration.md
@@ -938,6 +938,9 @@ See [set_grid_configuration](../../icommands/administrator/#set_grid_configurati
 
 ## Managing Parallel Transfer Threads
 
+!!! Note
+    The high ports are deprecated as of iRODS 4.3.4 and will be removed in a later version. Future versions of iRODS will perform parallel transfers using the zone port _(defaults to 1247)_. See [Parallel Transfer](../../system_overview/data_objects/#parallel-transfer) for more information.
+
 When transferring large amounts of data between the client and server or even between servers, the number of threads used to read and write data can be configured by the administrator.
 
 First, we will go over how to configure what "large amounts of data" means. This is a configurable value that is controlled by the `maximum_size_for_single_buffer_in_megabytes` setting in `server_config.json`. This setting controls the maximum size of a particular file or data object that will be put into an in-memory buffer. If the size of the file or data object to read or write exceeds this size, iRODS will initiate what is known as a "parallel transfer".

--- a/docs/system_overview/troubleshooting.md
+++ b/docs/system_overview/troubleshooting.md
@@ -439,6 +439,9 @@ The iRODS Rule Language rule engine variable scoping rules are summarized as:
 
 ## Parallel Transfer Port Contention
 
+!!! Note
+    The high ports are deprecated as of iRODS 4.3.4 and will be removed in a later version. Future versions of iRODS will perform parallel transfers using the zone port _(defaults to 1247)_. See [Parallel Transfer](../../system_overview/data_objects/#parallel-transfer) for more information.
+
 The iRODS Server will issue a LOG_NOTICE when it unsuccessfully attempts to claim an available port while setting up a parallel transfer portal.
 
 ```
@@ -709,6 +712,9 @@ Now that the replicas are at-rest and stale, they can be removed (or overwritten
 This technique should only be used to dig out of this serious situation or for testing purposes. Locked and intermediate replicas may truly be actively changing, so beware of potential data loss when using this technique.
 
 ## Firewalls dropping long-idle connections during parallel transfer
+
+!!! Note
+    The high ports are deprecated as of iRODS 4.3.4 and will be removed in a later version. Future versions of iRODS will perform parallel transfers using the zone port _(defaults to 1247)_. See [Parallel Transfer](../../system_overview/data_objects/#parallel-transfer) for more information.
 
 iRODS 4.2 and prior have three different ways to move data: single-buffer, streaming, and parallel transfer.  Both single-buffer and streaming transfers are on port 1247 and never have an idle connection.  The parallel transfer method connects on port 1247, constructs a portal of high ports, and then moves data over those high ports.  Once the transfer is complete, control returns to port 1247 for the connection cleanup and bookkeeping.  If the transfer takes long enough, local network firewall timeouts may be tripped and the initial port 1247 connection may be severed.
 


### PR DESCRIPTION
Here's a rendering of the wording for one section.

![image](https://github.com/user-attachments/assets/7a622347-72d7-4c0c-b1c9-e02422cac481)