### PR TITLE
[irods/irods#8278] Remove documentation on `msiSendMail` (main)

### DIFF
--- a/docs/system_overview/configuration.md
+++ b/docs/system_overview/configuration.md
@@ -57,11 +57,6 @@ This file defines the behavior of the server Agent that answers individual reque
         },
 
         // (Optional)
-        // Controls whether invocation of the msiSendMail microservice is allowed on the server.
-        // This option is NOT included on new installations or added during upgrades.
-        "enable_deprecated_msiSendMail": false,
-
-        // (Optional)
         // Contains settings for controlling the behavior of the internal Hostname cache.
         "hostname_cache": {
             // The amount of shared memory allocated to the Hostname cache.


### PR DESCRIPTION
Removes documentation on `msiSendMail`, which was removed in iRODS 5.0.