### PR TITLE
[irods/irods#7985] Remove documentation on modifying StrictACLs (main)

### DIFF
--- a/docs/system_overview/troubleshooting.md
+++ b/docs/system_overview/troubleshooting.md
@@ -377,10 +377,6 @@ This error occurs when there are no results for the database query that was exec
 
 This error can occur when an iRODS user tries to access an iRODS Data Object or Collection that belongs to another iRODS user without the owner having granted the appropriate permission (usually simply read or write).
 
-With the more restrictive "StrictACL" policy being turned "on" by default in iRODS 4.0+, this may occur more often than expected with iRODS 3.x.  Check the permissions carefully and use `ils -AL` to help diagnose what permissions *are* set for the Data Objects and Collections of interest.
-
-Modifying the "StrictACL" setting in the iRODS server's `core.re` file will apply the policy permanently; applying the policy via `irule` will have an impact only during the execution of that particular rule.
-
 ## Credentials
 
 !!! error

--- a/docs/system_overview/users_and_permissions.md
+++ b/docs/system_overview/users_and_permissions.md
@@ -12,29 +12,6 @@ Inheritance is a collection-specific setting that determines the permission sett
 
 Inheritance is especially useful when working with shared projects such as a public Collection to which all users should have read access. With Inheritance set to Enabled, any sub-Collections created under the public Collection will inherit the properties of the public Collection.  Therefore, a user with read access to the public Collection will also have read access to all Data Objects and Collections created in the public Collection.
 
-## StrictACL
-
-The iRODS setting 'StrictACL' is configured on by default in iRODS. This setting can be found in the `/etc/irods/core.re` file under acAclPolicy{}.
-
-The default setting is:
-
-~~~
-acAclPolicy {msiAclPolicy("STRICT");}
-~~~
-
-To set no policy, change the setting to:
-
-~~~
-acAclPolicy {}
-~~~
-
-or more explicitly:
-
-~~~
-acAclPolicy {msiAclPolicy("REGULAR");}
-~~~
-
-
 ## Tickets (Guest Access)
 
 Users are able to create tickets and associate them (one to one) with a Data Object or Collection. These are either system-generated 15-character pseudo-random strings, composed of upper and lower case characters 'A-Z' and '0-9'; or optionally specified by the user creating the ticket.


### PR DESCRIPTION
Issue quick link: irods/irods#7985

This PR attempts to remove all out-of-date documentation on StrictACLs. This PR also provides minor documentation informing that "StrictACL" is now always on as of iRODS 5.0.