### PR TITLE
[irods/irods#8605] Document Consortium's stance on API and ABI stability (main)

### DIFF
--- a/docs/developers/api_abi_stability.md
+++ b/docs/developers/api_abi_stability.md
@@ -1,0 +1,5 @@
+# API and ABI Stability
+
+The iRODS Consortium strives to maintain API stability and not break backward compatibility within a major version. This statement applies to stable public APIs only. Experimental features and projects which have not reached 1.0 status may experience breaking changes. Consumers of these features and projects must keep that in mind as they consider deploying them into production.
+
+The iRODS Consortium DOES NOT make any guarantees around ABI stability. This applies to iRODS libraries written in C, C++, and other languages which compile to machine code.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
     - Doxygen: 'doxygen/index.html'
     - Contributing: 'developers/contributing.md'
     - Development Tools: 'developers/development_tools.md'
+    - API and ABI Stability: 'developers/api_abi_stability.md'
     - Library Examples: 'developers/library_examples.md'
     - Logging: 'developers/logging.md'
     - Deprecation: 'developers/deprecation.md'


### PR DESCRIPTION
Here's a screenshot of the rendered documentation.

<img width="1237" height="468" alt="image" src="https://github.com/user-attachments/assets/bca5cbab-8216-4b7e-bb90-5753515bab0d" />

And here's what the navigation menu looks like. Tried to remove the button to the left of the section title, but failed. Also didn't spend a lot of time on that part.

<img width="314" height="292" alt="image" src="https://github.com/user-attachments/assets/ac28b02c-6c33-4c61-a76f-90929a77d656" />
