### PR TITLE
[134] remove 'full' from iexit instructions

### DIFF
--- a/docs/system_overview/configuration.md
+++ b/docs/system_overview/configuration.md
@@ -8,7 +8,7 @@ This file, in the home directory of the unix service account (default 'irods'), 
 
 ## ~/.irods/.irodsA
 
-This scrambled password file is saved after an `iinit` is run. If this file does not exist, then each iCommand will prompt for a password before authenticating with the iRODS server. If this file does exist, then each iCommand will read this file and use the contents as a cached password token and skip the password prompt. This file can be deleted manually or can be removed by running `iexit full`.
+This scrambled password file is saved after an `iinit` is run. If this file does not exist, then each iCommand will prompt for a password before authenticating with the iRODS server. If this file does exist, then each iCommand will read this file and use the contents as a cached password token and skip the password prompt. This file can be deleted manually or can be removed by running `iexit`.
 
 ## /etc/irods/server_config.json
 


### PR DESCRIPTION
This was removed in 4.3.0 (https://github.com/irods/irods/issues/2082).