### PR TITLE
[irods/irods8554] Adding documentation for resource_read_checksum_from_storage_device

### DIFF
--- a/dynamic_peps.json
+++ b/dynamic_peps.json
@@ -226,6 +226,18 @@
 				"paramName": "_ctx"
 			}]
 		}, {
+			"funcName": "resource_read_checksum_from_storage_device",
+			"paramList": [{
+				"paramType": "irods::plugin_context &",
+				"paramName": "_ctx"
+			}, {
+				"paramType": "const std::string *",
+				"paramName": "_checksum_scheme"
+			}, {
+				"paramType": "std::string *",
+				"paramName": "_returned_checksum"
+			}]
+		}, {
 			"funcName": "resource_readdir",
 			"paramList": [{
 				"paramType": "irods::plugin_context &",


### PR DESCRIPTION
This is for the RESOURCE_OP_READ_CHECKSUM_FROM_STORAGE_DEVICE resource plugin.
See irods/irods#8554