### PR TITLE
[irods/irods#8638] Add general info page for icommands (main)

### DIFF
--- a/docs/icommands/general_info.md
+++ b/docs/icommands/general_info.md
@@ -1,0 +1,13 @@
+#
+
+iCommands are a set of binaries which allow users to interact with an iRODS server via the command line. iCommands are available for all supported platforms.
+
+## Server Version Compatibility
+
+Starting with iRODS 5.1.0, the iCommands now perform a version check to verify compatibility with the connected server. If the major version number of the iCommands and server are not identical, a warning will be written to **stderr**. Users are strongly encouraged to keep these values in sync.
+
+The check can be disabled for all iCommands by setting the environment variable `ICOMMANDS_DETECT_SERVER_VERSION_MISMATCH` to `0`, as shown below.
+
+```sh
+export ICOMMANDS_DETECT_SERVER_VERSION_MISMATCH=0
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
     - Limitations and Restrictions: 'system_overview/limitations_and_restrictions.md'
     - Tips and Tricks: 'system_overview/tips_and_tricks.md'
  - iCommands:
+    - General Information: 'icommands/general_info.md'
     - Administrator: 'icommands/administrator.md'
     - User: 'icommands/user.md'
     - Metadata: 'icommands/metadata.md'


### PR DESCRIPTION
Companion PR: irods/irods#8957

There doesn't appear to be a good place to put general info about the icommands, so this PR adds a page for that.

This is motivated by the conversation at https://github.com/irods/irods/pull/8957#discussion_r3182394210.

Here's what it looks like.

<img width="1513" height="546" alt="image" src="https://github.com/user-attachments/assets/f2acb291-8ba2-4722-8db6-a10cd4e3541b" />
